### PR TITLE
Fix incompatible codec on some players/MacOS

### DIFF
--- a/diffusers_helper/utils.py
+++ b/diffusers_helper/utils.py
@@ -276,7 +276,7 @@ def save_bcthw_as_mp4(x, output_filename, fps=10):
     x = torch.clamp(x.float(), -1., 1.) * 127.5 + 127.5
     x = x.detach().cpu().to(torch.uint8)
     x = einops.rearrange(x, '(m n) c t h w -> t (m h) (n w) c', n=per_row)
-    torchvision.io.write_video(output_filename, x, fps=fps, video_codec='libx264', options={'crf': '0'})
+    torchvision.io.write_video(output_filename, x, fps=fps, video_codec='libx264', options={'crf': '17', 'pix_fmt': 'yuv420p'})
     return x
 
 


### PR DESCRIPTION
When the video is rendered, the current `crf=0` setting seem to push the profile of the rendered video to be `High 4:4:4 Predictive`, which seems to mismatch the `standard 4:2:0` from the `pix_fmt` H264 codec. This leads to the video not rendering on certain players and OS 

E.g.: the generated video does not render if I run the Gradio demo on a MacOS (with a backend in the cloud)

This PR fixes it while having a low CRF for maintaining the high quality