### PR TITLE
Add resolution selector

### DIFF
--- a/diffusers_helper/bucket_tools.py
+++ b/diffusers_helper/bucket_tools.py
@@ -1,4 +1,25 @@
 bucket_options = {
+    240: [
+        (224, 336),
+        (256, 304),
+        (288, 272),
+        (320, 240),
+        (352, 208),
+        (384, 176),
+    ],
+    320: [
+        (256, 576),
+        (288, 544),
+        (320, 512),
+        (352, 480),
+        (384, 448),
+        (416, 416),
+        (448, 384),
+        (480, 352),
+        (512, 320),
+        (544, 288),
+        (576, 256),
+    ],
     640: [
         (416, 960),
         (448, 864),
@@ -19,12 +40,12 @@ bucket_options = {
 
 
 def find_nearest_bucket(h, w, resolution=640):
-    min_metric = float('inf')
+    min_metric = float("inf")
     best_bucket = None
-    for (bucket_h, bucket_w) in bucket_options[resolution]:
+    for bucket_h, bucket_w in bucket_options[resolution]:
         metric = abs(h * bucket_w - w * bucket_h)
         if metric <= min_metric:
             min_metric = metric
             best_bucket = (bucket_h, bucket_w)
+    print(f"Best bucket: {best_bucket}")
     return best_bucket
-


### PR DESCRIPTION
One of the powerful features of Hunyuan Video is its ability to create nice videos at very low resolution. For example, Wan really struggles with it and mostly makes garbage at low res. So we should exploit it and allow user to choose a lower resolution to speed up inference tremendously.

For example, I went from 4.3s/it (640p) to 1.7s/it (320p) to 1.08 s/it (240p) on my 3090 Ti with TeaCache enabled. That's x2.5-x4 speed increase compared to the original 640p! I just added more buckets (320p and 240p) and a selector. The default is still 640p. Also the chosen bucket is printed to the console now.