### PR TITLE
Add prompt metadata to png exports

### DIFF
--- a/demo_gradio.py
+++ b/demo_gradio.py
@@ -14,6 +14,7 @@ import argparse
 import math
 
 from PIL import Image
+from PIL.PngImagePlugin import PngInfo
 from diffusers import AutoencoderKLHunyuanVideo
 from transformers import LlamaModel, CLIPTextModel, LlamaTokenizerFast, CLIPTokenizer
 from diffusers_helper.hunyuan import encode_prompt_conds, vae_decode, vae_encode, vae_decode_fake
@@ -141,7 +142,10 @@ def worker(input_image, prompt, n_prompt, seed, total_second_length, latent_wind
         height, width = find_nearest_bucket(H, W, resolution=640)
         input_image_np = resize_and_center_crop(input_image, target_width=width, target_height=height)
 
-        Image.fromarray(input_image_np).save(os.path.join(outputs_folder, f'{job_id}.png'))
+        metadata = PngInfo()
+        metadata.add_text("prompt", prompt)
+        
+        Image.fromarray(input_image_np).save(os.path.join(outputs_folder, f'{job_id}.png'), pnginfo=metadata)
 
         input_image_pt = torch.from_numpy(input_image_np).float() / 127.5 - 1
         input_image_pt = input_image_pt.permute(2, 0, 1)[None, :, None]


### PR DESCRIPTION
It is nice to be able to revisit ones prior prompts and I could not see that this was available.

Thanks for making this code available.