### PR TITLE
Fix url crafting when user is connecting via reverse proxy (bump gradio from 5.23.0 -> 5.23.2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 accelerate==1.6.0
 diffusers==0.33.1
 transformers==4.46.2
-gradio==5.23.0
+gradio==5.23.2
 sentencepiece==0.2.0
 pillow==11.1.0
 av==12.1.0


### PR DESCRIPTION
Resolves #16, Resolves #563 

This sidesteps a known bug in gradio 5.23 that causes route generation to fail. Without this change if a user reverse proxies loopback to test.local, for example, framepack will load. However, when a job is started it will hang indefinitely and show in the browser console `'https://test.local' has an unkown api call pattern.`